### PR TITLE
feat: AI content access views with HTML-to-markdown and FERPA filtering

### DIFF
--- a/tools/ai-content-access/create_ai_views.sql
+++ b/tools/ai-content-access/create_ai_views.sql
@@ -1,0 +1,181 @@
+-- Canvas AI Content Access — PostgreSQL Views
+-- These views make course content accessible to AI agents with:
+-- 1. FERPA-safe filtering (only published/active content)
+-- 2. HTML→plaintext conversion (strips tags for agent readability)
+-- 3. Pre-joined tables (no agent SQL composition needed for common queries)
+--
+-- For the fork model, this runs as a Rails migration.
+-- For testing, run directly against PostgreSQL.
+
+-- ============================================================
+-- UTILITY: Simple HTML tag stripper
+-- A real deployment would use a proper HTML→Markdown converter.
+-- This basic version strips tags for testing the view pattern.
+-- ============================================================
+
+CREATE OR REPLACE FUNCTION strip_html_tags(html TEXT)
+RETURNS TEXT AS $$
+BEGIN
+  IF html IS NULL THEN RETURN NULL; END IF;
+  -- Remove script/style blocks entirely
+  html := regexp_replace(html, '<script[^>]*>.*?</script>', '', 'gis');
+  html := regexp_replace(html, '<style[^>]*>.*?</style>', '', 'gis');
+  -- Convert common elements to markdown-ish text
+  html := regexp_replace(html, '<h1[^>]*>', E'\n# ', 'gi');
+  html := regexp_replace(html, '<h2[^>]*>', E'\n## ', 'gi');
+  html := regexp_replace(html, '<h3[^>]*>', E'\n### ', 'gi');
+  html := regexp_replace(html, '</h[1-6]>', E'\n', 'gi');
+  html := regexp_replace(html, '<li[^>]*>', E'\n- ', 'gi');
+  html := regexp_replace(html, '<br\s*/?>', E'\n', 'gi');
+  html := regexp_replace(html, '<p[^>]*>', E'\n', 'gi');
+  html := regexp_replace(html, '</p>', '', 'gi');
+  html := regexp_replace(html, '<strong[^>]*>', '**', 'gi');
+  html := regexp_replace(html, '</strong>', '**', 'gi');
+  html := regexp_replace(html, '<em[^>]*>', '*', 'gi');
+  html := regexp_replace(html, '</em>', '*', 'gi');
+  html := regexp_replace(html, '<code[^>]*>', '`', 'gi');
+  html := regexp_replace(html, '</code>', '`', 'gi');
+  html := regexp_replace(html, '<td[^>]*>', ' | ', 'gi');
+  html := regexp_replace(html, '<tr[^>]*>', E'\n', 'gi');
+  html := regexp_replace(html, '<th[^>]*>', ' | **', 'gi');
+  html := regexp_replace(html, '</th>', '** ', 'gi');
+  -- Strip remaining tags
+  html := regexp_replace(html, '<[^>]+>', '', 'g');
+  -- Decode common entities
+  html := replace(html, '&amp;', '&');
+  html := replace(html, '&lt;', '<');
+  html := replace(html, '&gt;', '>');
+  html := replace(html, '&quot;', '"');
+  html := replace(html, '&#39;', '''');
+  html := replace(html, '&nbsp;', ' ');
+  -- Clean up excessive whitespace
+  html := regexp_replace(html, E'\n{3,}', E'\n\n', 'g');
+  html := trim(html);
+  RETURN html;
+END;
+$$ LANGUAGE plpgsql IMMUTABLE;
+
+-- ============================================================
+-- AI VIEWS — Pre-made queries for common agent access patterns
+-- ============================================================
+
+-- All published assignments for a course, FERPA-safe
+CREATE OR REPLACE VIEW ai_course_assignments AS
+SELECT
+  a.id,
+  a.title,
+  strip_html_tags(a.description) AS description_clean,
+  a.due_at,
+  a.lock_at,
+  a.unlock_at,
+  a.points_possible,
+  a.grading_type,
+  a.submission_types,
+  a.context_id AS course_id,
+  a.updated_at
+FROM assignments a
+WHERE a.workflow_state = 'published'
+  AND a.context_type = 'Course';
+
+-- All published pages
+CREATE OR REPLACE VIEW ai_course_pages AS
+SELECT
+  wp.id,
+  wp.title,
+  wp.url,
+  strip_html_tags(wp.body) AS body_clean,
+  w.context_id AS course_id,
+  wp.updated_at
+FROM wiki_pages wp
+JOIN wikis w ON wp.wiki_id = w.id
+WHERE wp.workflow_state = 'active'
+  AND w.context_type = 'Course';
+
+-- Module structure with items resolved
+CREATE OR REPLACE VIEW ai_course_modules AS
+SELECT
+  cm.id AS module_id,
+  cm.name AS module_name,
+  cm.position,
+  cm.prerequisites,
+  cm.completion_requirements,
+  ct.position AS item_position,
+  ct.title AS item_title,
+  ct.content_type,
+  ct.content_id,
+  ct.url AS external_url,
+  ct.indent,
+  cm.context_id AS course_id
+FROM context_modules cm
+LEFT JOIN content_tags ct
+  ON ct.context_module_id = cm.id
+  AND ct.workflow_state = 'active'
+WHERE cm.workflow_state = 'active'
+  AND cm.context_type = 'Course'
+ORDER BY cm.position, ct.position;
+
+-- Announcements (recent first)
+CREATE OR REPLACE VIEW ai_course_announcements AS
+SELECT
+  dt.id,
+  dt.title,
+  strip_html_tags(dt.message) AS message_clean,
+  dt.posted_at,
+  dt.context_id AS course_id,
+  dt.updated_at
+FROM discussion_topics dt
+WHERE dt.type = 'Announcement'
+  AND dt.workflow_state = 'active'
+  AND dt.context_type = 'Course'
+ORDER BY dt.posted_at DESC;
+
+-- Course syllabus
+CREATE OR REPLACE VIEW ai_course_syllabus AS
+SELECT
+  c.id AS course_id,
+  c.name,
+  c.course_code,
+  strip_html_tags(c.syllabus_body) AS syllabus_clean
+FROM courses c
+WHERE c.workflow_state = 'available';
+
+-- Files list
+CREATE OR REPLACE VIEW ai_course_files AS
+SELECT
+  a.id,
+  a.display_name,
+  a.filename,
+  a.content_type,
+  a.size,
+  a.context_id AS course_id,
+  a.updated_at
+FROM attachments a
+WHERE a.file_state = 'available'
+  AND a.context_type = 'Course';
+
+-- Unified content search (all content types in one view)
+CREATE OR REPLACE VIEW ai_course_content AS
+SELECT course_id, 'assignment' AS content_type, id AS content_id,
+       title, description_clean AS content_clean, due_at AS relevant_date,
+       points_possible, updated_at
+FROM ai_course_assignments
+UNION ALL
+SELECT course_id, 'page', id, title, body_clean, NULL, NULL, updated_at
+FROM ai_course_pages
+UNION ALL
+SELECT course_id, 'announcement', id, title, message_clean, posted_at, NULL, updated_at
+FROM ai_course_announcements;
+
+-- Course manifest (compact index for agent system prompt)
+CREATE OR REPLACE VIEW ai_course_manifest AS
+SELECT
+  c.id AS course_id,
+  c.name AS course_name,
+  c.course_code,
+  (SELECT count(*) FROM context_modules WHERE context_id = c.id AND workflow_state = 'active') AS module_count,
+  (SELECT count(*) FROM assignments WHERE context_id = c.id AND workflow_state = 'published') AS assignment_count,
+  (SELECT count(*) FROM wiki_pages wp JOIN wikis w ON wp.wiki_id = w.id WHERE w.context_id = c.id AND wp.workflow_state = 'active') AS page_count,
+  (SELECT count(*) FROM discussion_topics WHERE context_id = c.id AND type = 'Announcement' AND workflow_state = 'active') AS announcement_count,
+  (SELECT count(*) FROM attachments WHERE context_id = c.id AND file_state = 'available') AS file_count
+FROM courses c
+WHERE c.workflow_state = 'available';

--- a/tools/ai-content-access/seed_test_data.sql
+++ b/tools/ai-content-access/seed_test_data.sql
@@ -1,0 +1,69 @@
+-- Canvas AI Content Access — Test Data
+-- Seed data based on our actual CSE 290R course (407700)
+
+-- Course
+INSERT INTO courses (id, name, course_code, syllabus_body, workflow_state) VALUES
+(407700, 'Applied AI for Software Engineering', 'CSE 290R',
+ '<div style="margin:0;padding:0;font-family:Georgia,serif;font-size:17px;"><h1 style="font-size:2rem;">Applied AI for Software Engineering</h1><p style="margin:0 0 1.1em;">Credits: 2. Format: Two meetings per week. Duration: 14 weeks.</p><h2 style="font-size:1.4rem;">Late Policy</h2><p>Late work will only be accepted with prior consent from the instructor or teaching assistant.</p><h2>Grading</h2><p>Phase 1 portfolio: 35%. Phase 2 MVP: 40%. Participation: 15%. Reflections: 10%.</p><h2>Academic Honesty</h2><p>Students do their own work with AI tools as specified in the course policy.</p></div>',
+ 'available');
+
+-- Wiki for course
+INSERT INTO wikis (id, context_id, context_type) VALUES (1, 407700, 'Course');
+
+-- Wiki Pages (instruction pages)
+INSERT INTO wiki_pages (id, wiki_id, title, url, body, workflow_state) VALUES
+(1, 1, 'Instruction 1.2: Agents', 'instruction-1-dot-2-agents',
+ '<h1>Instruction 1.2: Agents</h1><h2>Definitions</h2><p><strong>Agents</strong>: AI systems that observe, reason, and act autonomously to achieve objectives.</p><p><strong>Markdown</strong>: Lightweight markup language for formatting text.</p>',
+ 'active'),
+(2, 1, 'Instruction 2.1: Feature Planning', 'instruction-2-dot-1-feature-planning',
+ '<h1>Instruction 2.1: Feature Planning</h1><h2>Definitions</h2><p><strong>Feature</strong>: A distinct, user-facing capability that adds value.</p><p><strong>Feature Scope</strong>: Boundaries of what a feature includes.</p><p><strong>FERPA</strong>: Federal law protecting student education records.</p>',
+ 'active');
+
+-- Assignments
+INSERT INTO assignments (id, context_id, title, description, due_at, points_possible, workflow_state) VALUES
+(16835639, 407700, 'Prepare: 3.2 - Status',
+ '<div style="font-family:Georgia;"><p>This is a <strong>graded survey</strong>: you receive credit for thoughtful completion.</p><p><strong>Unlimited attempts</strong> are allowed.</p></div>',
+ '2026-05-07 10:15:00', 10, 'published'),
+(16835669, 407700, 'Lab 3.2: Agent Driven Feature Implementation',
+ '<div style="font-family:Georgia;font-size:17px;"><h1 style="font-size:2rem;">Lab 3.2: Agent Driven Feature Implementation</h1><p>You will begin implementing the Canvas feature you scoped and planned.</p><h2>Goal</h2><ol><li>Plans as source of truth</li><li>Implementation agent: agents/feature-implementation.md</li><li>Board workflow via MCP</li></ol><h2>Repository layout</h2><table><tr><th>Path</th><th>Purpose</th></tr><tr><td>agents/feature-implementation.md</td><td>Agent spec</td></tr><tr><td>agents/tasks/feature-1/implementation-evidence.md</td><td>Evidence pack</td></tr></table></div>',
+ '2026-05-09 23:59:59', 30, 'published'),
+(16835641, 407700, 'Prepare: 4.1 - Quality Assurance',
+ '<div><p>Review definitions for QA, unit testing, TDD.</p><p><strong>Unlimited attempts.</strong> Highest score kept.</p></div>',
+ '2026-05-12 10:15:00', 10, 'published'),
+(16835671, 407700, 'Lab 4.1: Quality Assurance',
+ '<div style="font-family:Georgia;"><h1>Lab 4.1: Quality Assurance</h1><p>Add a dedicated QA agent alongside your implementation workflow.</p><h2>Repository layout</h2><table><tr><th>Path</th><th>Purpose</th></tr><tr><td>agents/quality-assurance.md</td><td>QA agent spec</td></tr><tr><td>agents/tasks/feature-1/qa-lab-evidence.md</td><td>Test evidence</td></tr></table></div>',
+ '2026-05-14 23:59:00', 30, 'published');
+
+-- An unpublished assignment (should NOT appear in AI views — FERPA)
+INSERT INTO assignments (id, context_id, title, description, due_at, points_possible, workflow_state) VALUES
+(99999, 407700, 'SECRET DRAFT EXAM', '<p>This should never be visible to students.</p>', '2026-06-01 23:59:00', 100, 'unpublished');
+
+-- Modules
+INSERT INTO context_modules (id, context_id, name, position, prerequisites, workflow_state) VALUES
+(4590003, 407700, 'Brownfield - Week 1', 1, '[]', 'active'),
+(4590005, 407700, 'Brownfield - Week 2', 2, '[{"id":4590003,"type":"context_module","name":"Brownfield - Week 1"}]', 'active'),
+(4590007, 407700, 'Brownfield - Week 3', 3, '[{"id":4590005,"type":"context_module","name":"Brownfield - Week 2"}]', 'active'),
+(4590009, 407700, 'Brownfield - Week 4', 4, '[{"id":4590007,"type":"context_module","name":"Brownfield - Week 3"}]', 'active');
+
+-- Content Tags (module items)
+INSERT INTO content_tags (context_id, context_module_id, content_type, content_id, title, position, workflow_state) VALUES
+(407700, 4590007, 'ContextModuleSubHeader', NULL, 'Day 5 - Memory', 1, 'active'),
+(407700, 4590007, 'Assignment', 16835639, 'Prepare: 3.2 - Status', 2, 'active'),
+(407700, 4590007, 'Assignment', 16835669, 'Lab 3.2: Agent Driven Feature Implementation', 3, 'active'),
+(407700, 4590009, 'ContextModuleSubHeader', NULL, 'Day 7 - Quality Assurance', 1, 'active'),
+(407700, 4590009, 'Assignment', 16835641, 'Prepare: 4.1 - Quality Assurance', 2, 'active'),
+(407700, 4590009, 'Assignment', 16835671, 'Lab 4.1: Quality Assurance', 3, 'active');
+
+-- Announcements
+INSERT INTO discussion_topics (id, context_id, title, message, type, workflow_state, posted_at) VALUES
+(1, 407700, 'Welcome to CSE 290R!',
+ '<p style="font-family:Georgia;">Welcome to Applied AI for Software Engineering. Please review the syllabus and complete your tool setup before Day 1.</p>',
+ 'Announcement', 'active', '2026-04-20 09:00:00'),
+(2, 407700, 'Lab 3.1 Submission Reminder',
+ '<p>Remember to submit Lab 3.1 by Tuesday 11:59 PM. Include your memory-practice.md and AWS evidence.</p>',
+ 'Announcement', 'active', '2026-05-04 10:00:00');
+
+-- Files
+INSERT INTO attachments (id, context_id, display_name, filename, content_type, size, file_state) VALUES
+(1, 407700, 'Course Overview Slides', 'course-overview.pdf', 'application/pdf', 2048000, 'available'),
+(2, 407700, 'Canvas Architecture Diagram', 'canvas-arch.png', 'image/png', 512000, 'available');

--- a/tools/ai-content-access/setup_test_schema.sql
+++ b/tools/ai-content-access/setup_test_schema.sql
@@ -1,0 +1,111 @@
+-- Canvas AI Content Access — Test Schema
+-- Minimal reproduction of Canvas tables needed for AI views
+-- This mirrors the actual Canvas schema for the relevant tables
+
+-- Courses
+CREATE TABLE IF NOT EXISTS courses (
+  id BIGSERIAL PRIMARY KEY,
+  name TEXT NOT NULL,
+  course_code TEXT,
+  syllabus_body TEXT,  -- HTML content
+  workflow_state TEXT DEFAULT 'available',
+  created_at TIMESTAMP DEFAULT NOW(),
+  updated_at TIMESTAMP DEFAULT NOW()
+);
+
+-- Wikis (each course has one wiki)
+CREATE TABLE IF NOT EXISTS wikis (
+  id BIGSERIAL PRIMARY KEY,
+  context_id BIGINT,
+  context_type TEXT DEFAULT 'Course',
+  created_at TIMESTAMP DEFAULT NOW()
+);
+
+-- Wiki Pages
+CREATE TABLE IF NOT EXISTS wiki_pages (
+  id BIGSERIAL PRIMARY KEY,
+  wiki_id BIGINT REFERENCES wikis(id),
+  title TEXT NOT NULL,
+  url TEXT,  -- slug
+  body TEXT,  -- HTML content
+  workflow_state TEXT DEFAULT 'active',
+  created_at TIMESTAMP DEFAULT NOW(),
+  updated_at TIMESTAMP DEFAULT NOW()
+);
+
+-- Assignments
+CREATE TABLE IF NOT EXISTS assignments (
+  id BIGSERIAL PRIMARY KEY,
+  context_id BIGINT,
+  context_type TEXT DEFAULT 'Course',
+  title TEXT NOT NULL,
+  description TEXT,  -- HTML content
+  due_at TIMESTAMP,
+  lock_at TIMESTAMP,
+  unlock_at TIMESTAMP,
+  points_possible FLOAT,
+  grading_type TEXT DEFAULT 'points',
+  submission_types TEXT DEFAULT 'online_text_entry',
+  workflow_state TEXT DEFAULT 'published',
+  created_at TIMESTAMP DEFAULT NOW(),
+  updated_at TIMESTAMP DEFAULT NOW()
+);
+
+-- Discussion Topics (also used for Announcements via STI)
+CREATE TABLE IF NOT EXISTS discussion_topics (
+  id BIGSERIAL PRIMARY KEY,
+  context_id BIGINT,
+  context_type TEXT DEFAULT 'Course',
+  title TEXT,
+  message TEXT,  -- HTML content
+  type TEXT,  -- NULL for discussions, 'Announcement' for announcements
+  workflow_state TEXT DEFAULT 'active',
+  posted_at TIMESTAMP DEFAULT NOW(),
+  created_at TIMESTAMP DEFAULT NOW(),
+  updated_at TIMESTAMP DEFAULT NOW()
+);
+
+-- Context Modules
+CREATE TABLE IF NOT EXISTS context_modules (
+  id BIGSERIAL PRIMARY KEY,
+  context_id BIGINT,
+  context_type TEXT DEFAULT 'Course',
+  name TEXT NOT NULL,
+  position INTEGER,
+  prerequisites TEXT,  -- serialized JSON array
+  completion_requirements TEXT,  -- serialized JSON
+  workflow_state TEXT DEFAULT 'active',
+  unlock_at TIMESTAMP,
+  created_at TIMESTAMP DEFAULT NOW(),
+  updated_at TIMESTAMP DEFAULT NOW()
+);
+
+-- Content Tags (polymorphic module items)
+CREATE TABLE IF NOT EXISTS content_tags (
+  id BIGSERIAL PRIMARY KEY,
+  context_id BIGINT,
+  context_type TEXT DEFAULT 'Course',
+  context_module_id BIGINT REFERENCES context_modules(id),
+  content_id BIGINT,
+  content_type TEXT,  -- 'Assignment', 'WikiPage', 'DiscussionTopic', etc.
+  title TEXT,
+  url TEXT,  -- for ExternalUrl type
+  position INTEGER,
+  indent INTEGER DEFAULT 0,
+  workflow_state TEXT DEFAULT 'active',
+  created_at TIMESTAMP DEFAULT NOW()
+);
+
+-- Attachments (files)
+CREATE TABLE IF NOT EXISTS attachments (
+  id BIGSERIAL PRIMARY KEY,
+  context_id BIGINT,
+  context_type TEXT DEFAULT 'Course',
+  filename TEXT,
+  display_name TEXT,
+  content_type TEXT,
+  size BIGINT,
+  file_state TEXT DEFAULT 'available',
+  created_at TIMESTAMP DEFAULT NOW(),
+  updated_at TIMESTAMP DEFAULT NOW()
+);

--- a/tools/ai-content-access/test_ai_views.sql
+++ b/tools/ai-content-access/test_ai_views.sql
@@ -1,0 +1,155 @@
+-- Canvas AI Content Access — Tests
+-- Verifies views work correctly with AAA pattern (Arrange-Act-Assert)
+-- Arrange: test data loaded via seed_test_data.sql
+-- Act: query each view
+-- Assert: check results match expectations
+
+\echo '=========================================='
+\echo 'TEST 1: FERPA — unpublished content hidden'
+\echo '=========================================='
+-- The unpublished assignment (id=99999) should NOT appear
+SELECT
+  CASE WHEN count(*) = 0 THEN 'PASS: Unpublished assignment correctly hidden'
+       ELSE 'FAIL: Unpublished assignment visible — FERPA violation!'
+  END AS test_result
+FROM ai_course_assignments
+WHERE course_id = 407700 AND title = 'SECRET DRAFT EXAM';
+
+\echo ''
+\echo '=========================================='
+\echo 'TEST 2: Published assignments visible'
+\echo '=========================================='
+SELECT
+  CASE WHEN count(*) = 4 THEN 'PASS: All 4 published assignments visible'
+       ELSE 'FAIL: Expected 4 published assignments, got ' || count(*)
+  END AS test_result
+FROM ai_course_assignments
+WHERE course_id = 407700;
+
+\echo ''
+\echo '=========================================='
+\echo 'TEST 3: HTML stripped from assignments'
+\echo '=========================================='
+SELECT
+  CASE WHEN description_clean NOT LIKE '%<div%' AND description_clean NOT LIKE '%style=%'
+       THEN 'PASS: HTML tags stripped from assignment description'
+       ELSE 'FAIL: HTML tags still present in description_clean'
+  END AS test_result
+FROM ai_course_assignments
+WHERE id = 16835669;
+
+\echo ''
+\echo '=========================================='
+\echo 'TEST 4: Syllabus accessible and cleaned'
+\echo '=========================================='
+SELECT
+  CASE WHEN syllabus_clean IS NOT NULL
+        AND syllabus_clean NOT LIKE '%<div%'
+        AND syllabus_clean LIKE '%Late Policy%'
+       THEN 'PASS: Syllabus accessible, cleaned, contains Late Policy'
+       ELSE 'FAIL: Syllabus missing, still has HTML, or missing content'
+  END AS test_result
+FROM ai_course_syllabus
+WHERE course_id = 407700;
+
+\echo ''
+\echo '=========================================='
+\echo 'TEST 5: Module structure preserved'
+\echo '=========================================='
+SELECT
+  CASE WHEN count(DISTINCT module_id) = 4 THEN 'PASS: All 4 modules visible'
+       ELSE 'FAIL: Expected 4 modules, got ' || count(DISTINCT module_id)
+  END AS test_result
+FROM ai_course_modules
+WHERE course_id = 407700;
+
+\echo ''
+\echo '=========================================='
+\echo 'TEST 6: Module prerequisites preserved'
+\echo '=========================================='
+SELECT
+  CASE WHEN prerequisites LIKE '%Week 2%'
+       THEN 'PASS: Week 3 prerequisite chain preserved (requires Week 2)'
+       ELSE 'FAIL: Prerequisite data missing or corrupted'
+  END AS test_result
+FROM ai_course_modules
+WHERE course_id = 407700 AND module_name = 'Brownfield - Week 3'
+LIMIT 1;
+
+\echo ''
+\echo '=========================================='
+\echo 'TEST 7: Announcements visible and cleaned'
+\echo '=========================================='
+SELECT
+  CASE WHEN count(*) = 2 AND bool_and(message_clean NOT LIKE '%<p%')
+       THEN 'PASS: 2 announcements visible, HTML cleaned'
+       ELSE 'FAIL: Announcement count or HTML cleaning issue'
+  END AS test_result
+FROM ai_course_announcements
+WHERE course_id = 407700;
+
+\echo ''
+\echo '=========================================='
+\echo 'TEST 8: Unified content search works'
+\echo '=========================================='
+SELECT
+  CASE WHEN count(*) > 0 THEN 'PASS: Found content matching "Quality Assurance"'
+       ELSE 'FAIL: Unified search returned no results'
+  END AS test_result
+FROM ai_course_content
+WHERE course_id = 407700 AND content_clean ILIKE '%quality assurance%';
+
+\echo ''
+\echo '=========================================='
+\echo 'TEST 9: Course manifest counts correct'
+\echo '=========================================='
+SELECT
+  CASE WHEN assignment_count = 4 AND module_count = 4 AND announcement_count = 2
+       THEN 'PASS: Manifest counts correct (4 assignments, 4 modules, 2 announcements)'
+       ELSE 'FAIL: Manifest counts wrong — assignments=' || assignment_count
+            || ' modules=' || module_count || ' announcements=' || announcement_count
+  END AS test_result
+FROM ai_course_manifest
+WHERE course_id = 407700;
+
+\echo ''
+\echo '=========================================='
+\echo 'TEST 10: Pages accessible via wiki join'
+\echo '=========================================='
+SELECT
+  CASE WHEN count(*) = 2 AND bool_and(body_clean NOT LIKE '%<h1%')
+       THEN 'PASS: 2 pages visible, HTML cleaned, wiki join works'
+       ELSE 'FAIL: Page count or HTML cleaning issue'
+  END AS test_result
+FROM ai_course_pages
+WHERE course_id = 407700;
+
+\echo ''
+\echo '=========================================='
+\echo 'TEST 11: Due-this-week filter works'
+\echo '=========================================='
+-- This tests that the view supports date filtering (agent would add WHERE clause)
+SELECT
+  CASE WHEN count(*) >= 0 THEN 'PASS: Date filtering on ai_course_assignments works (found ' || count(*) || ' due this week)'
+       ELSE 'FAIL: Date filtering error'
+  END AS test_result
+FROM ai_course_assignments
+WHERE course_id = 407700
+  AND due_at BETWEEN NOW() AND NOW() + interval '7 days';
+
+\echo ''
+\echo '=========================================='
+\echo 'TEST 12: Files view works'
+\echo '=========================================='
+SELECT
+  CASE WHEN count(*) = 2 THEN 'PASS: 2 files visible'
+       ELSE 'FAIL: Expected 2 files, got ' || count(*)
+  END AS test_result
+FROM ai_course_files
+WHERE course_id = 407700;
+
+\echo ''
+\echo '=========================================='
+\echo 'SUMMARY'
+\echo '=========================================='
+\echo 'All 12 tests completed. Review results above.'


### PR DESCRIPTION
## Work Item
Sync Canvas course content to local content directory (Project item #5)

## Changes
- create_ai_views.sql: 8 PostgreSQL views + strip_html_tags() function
- setup_test_schema.sql: Minimal Canvas schema for testing
- seed_test_data.sql: Test data based on real CSE 290R course
- test_ai_views.sql: 12 AAA-pattern tests (all passing)

## Testing
12/12 tests passing. FERPA verified (unpublished hidden). HTML cleaning verified.